### PR TITLE
Add support for django-ipware 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "django-ipware>=2.1,<4.1",
     ],
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-django", "pytest-cov"],
+    tests_require=["pytest", "pytest-django", "pytest-cov", "tomli<2.0;python_version=='3.6'"],
     python_requires=">=3.6",
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(f):
 
 setup(
     name="drf-recaptcha",
-    version="2.0.6",
+    version="2.0.7",
     description="Django rest framework recaptcha field serializer.",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "django>=2.2,<4.1",
         "djangorestframework>=3.9,<4.0",
-        "django-ipware>=2.1,<4.0",
+        "django-ipware>=2.1,<4.1",
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest", "pytest-django", "pytest-cov"],


### PR DESCRIPTION
The PR following #15. I updated the `django-ipware` dependency and I bumped the version of `drf-recaptcha`