### PR TITLE
fix: fix handling of v3 required score when set to 0

### DIFF
--- a/drf_recaptcha/fields.py
+++ b/drf_recaptcha/fields.py
@@ -79,9 +79,16 @@ class ReCaptchaV3Field(CharField):
 
         self.required_score = (
             action_score_from_settings
-            or required_score
-            or default_score_from_settings
-            or DEFAULT_V3_SCORE
+            if action_score_from_settings is not None
+            else (
+                required_score
+                if required_score is not None
+                else (
+                    default_score_from_settings
+                    if default_score_from_settings is not None
+                    else DEFAULT_V3_SCORE
+                )
+            )
         )
 
         secret_key = secret_key or settings.DRF_RECAPTCHA_SECRET_KEY

--- a/drf_recaptcha/validators.py
+++ b/drf_recaptcha/validators.py
@@ -131,7 +131,7 @@ class ReCaptchaV3Validator(ReCaptchaValidator):
 
         action = check_captcha_response.extra_data.get("action", "")
 
-        if self.recaptcha_required_score >= float(self.score):
+        if self.recaptcha_required_score > float(self.score):
             logger.error(
                 "ReCAPTCHA validation failed due to score of %s"
                 " being lower than the required amount for action '%s'.",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -118,3 +118,20 @@ def test_recaptcha_v3_field_score_improperly_configured(
         ReCaptchaV3Field(action="test_action", **params)
 
     assert str(exc_info.value) == error
+
+
+@pytest.mark.parametrize(
+    ("params", "from_settings", "settings_default", "expected"),
+    [
+        ({"required_score": 0}, {}, None, 0),  # Expect 0 because it's explicitly set
+    ],
+)
+def test_recaptcha_v3_field_valid_scores(
+    params, from_settings, settings_default, expected, settings
+):
+
+    settings.DRF_RECAPTCHA_ACTION_V3_SCORES = from_settings
+    settings.DRF_RECAPTCHA_DEFAULT_V3_SCORE = settings_default
+
+    field = ReCaptchaV3Field(action="test_action", **params)
+    assert field.required_score == expected

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -20,6 +20,13 @@ def _drf_recaptcha_testing(settings):
                 is_valid=True, extra_data={"score": 0.6, "action": "test_action"}
             ),
         ),
+        (
+            ReCaptchaV3Validator,
+            {"action": "test_action", "required_score": 0.5},
+            RecaptchaResponse(
+                is_valid=True, extra_data={"score": 0.5, "action": "test_action"}
+            ),
+        ),
     ]
 )
 def validator_with_mocked_captcha_valid_response(request, mocker):


### PR DESCRIPTION
Fixes two closely related bugs:

1. Previously if the required score was set to 0 (in an attempt to not i actually block anything), the default of 0.5 would be used instead. This was due to incorrect logic when checking for None values. This changes fixes this handling so that a requred score of 0 may be set.
2. The docs state that "Validation is passed if the score value returned by Google is greater than or equal to required score." However the code was actually checking for a score greater tahan required, not greater than or equal to. This change fixes the logic to match the stated behavior.

cc. @davidalexandercurrie