### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on: [ push ]
 


### PR DESCRIPTION
Potential fix for [https://github.com/llybin/drf-recaptcha/security/code-scanning/1](https://github.com/llybin/drf-recaptcha/security/code-scanning/1)

To fix the problem, add a `permissions` block specifying the minimum required permissions. For most testing and dependency install job workflows, `contents: read` is sufficient and safe. Since the workflow only checks out the code, installs dependencies, runs tests, and uploads coverage to Codacy (which uses an external token), no additional token permissions are needed. The permissions block should be added at the root of the workflow so it applies to all jobs within the file. To implement, insert the following lines after the workflow `name:` but before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
