### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -2,6 +2,8 @@ name: Ruff
 on: [ push, pull_request ]
 jobs:
   ruff:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/llybin/drf-recaptcha/security/code-scanning/2](https://github.com/llybin/drf-recaptcha/security/code-scanning/2)

The best way to fix the problem is to explicitly add a `permissions` block limiting the job’s access to only read contents. Since there is only one job in the workflow, and the workflow has no top-level `permissions` key, the best fix is to add `permissions: contents: read` at the job level (`ruff`). This will override any defaults and ensure that the GitHub Actions token is granted only read access to the repository contents. The most appropriate location for this block is directly above the `runs-on` line for the job. No additional imports, methods, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
